### PR TITLE
Add support for extra.error as an Error

### DIFF
--- a/lib/gelf-pro.js
+++ b/lib/gelf-pro.js
@@ -154,6 +154,9 @@ gelf.message = function (message, lvl, extra, cb) {
   if (_.isError(extra)) {
     extra = {error: {message: extra.message, stack: extra.stack}};
   }
+  if (!_.isUndefined(extra) && _.isError(extra.error)) {
+    extra.error = {error: {message: extra.error.message, stack: extra.error.stack}};
+  }
 
   // eslint-disable-next-line
   extra = _.merge({}, {short_message: message, level: lvl}, this.config.fields, extra || {});


### PR DESCRIPTION
Hi,

I have been running into an situation lately where i want to log an error along with other task information. In those cases I end up having to pass through the trace manually or else it will get dropped.

I made a small PR that checks if `extra.error` exists and handles it like if you passed it in as extra.

Also thanks for making such a solid library.