### PR TITLE
Resolves #46.

### DIFF
--- a/lib/adapter/udp.js
+++ b/lib/adapter/udp.js
@@ -111,8 +111,7 @@ adapter.send = function (message, callback) {
       }
     ],
     function (err, result) {
-      client.close();
-      return callback(err, result);
+      client.close(callback(err, result));
     }
   );
   return this;


### PR DESCRIPTION
I ports are not releasing in a timely manner due as a result of DNS
timeout due to order of operations. I'm suggesting that the `send`
callback be triggered as the callback of `client.close()` rather than as
the return value of `async.waterfalls`'s callback.