### PR TITLE
Changed this.message to gelf.message

### DIFF
--- a/lib/gelf-pro.js
+++ b/lib/gelf-pro.js
@@ -193,7 +193,7 @@ gelf.message = function (message, lvl, extra, cb) {
 // defining default functions like info(), error(), etc.
 _.forEach(gelf.config.levels, function (idx, lvl) {
   this[lvl] = function (message, extra, cb) {
-    this.message(message, idx, extra, cb);
+    gelf.message(message, idx, extra, cb);
   };
 }.bind(gelf));
 


### PR DESCRIPTION
this.message is giving an error, works when changed to gelf.message

Here is the error that appeared before this fix:

```
TypeError: Cannot read property 'message' of undefined
    at (anonymous function) (/root/sp-api/node_modules/gelf-pro/lib/gelf-pro.js:196:6)
    at /root/sp-api/src/integrations/graylog.ts:98:5
    at new Promise (<anonymous>)
    at /root/sp-api/src/integrations/graylog.ts:96:10
    at Generator.next (<anonymous>)
    at fulfilled (/root/sp-api/dist/integrations/graylog.js:7:58)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:743:3)
```

System:
Ubuntu 16.04
Node v10.15
Typescript 3.4.2