### PR TITLE
Add return value types to all functions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -25,20 +25,20 @@ declare module 'gelf-pro' {
   export function setConfig(opts: Partial<Settings>): void;
   export function getAdapter(): Adapter;
   export function getStringFromObject(object: object): string;
-  export function send(message: Message, callback: MessageCallback);
-  export function message(message: Message, lvl: number, extra?: MessageExtra, callback?: MessageCallback);
+  export function send(message: Message, callback: MessageCallback): void;
+  export function message(message: Message, lvl: number, extra?: MessageExtra, callback?: MessageCallback): void;
 
   export interface Logger {
     setConfig(opts: Partial<Settings>): Logger;
     getAdapter(): Adapter;
     getStringFromObject(object: object): string;
-    send(message: Message, callback: MessageCallback);
-    message(message: Message, lvl: number, extra: any, callback: MessageCallback);
+    send(message: Message, callback: MessageCallback): void;
+    message(message: Message, lvl: number, extra: any, callback: MessageCallback): void;
   }
 
   export interface Adapter {
     setOptions(options: any): Adapter;
-    send(message: Message, callback: MessageCallback);
+    send(message: Message, callback: MessageCallback): void;
   }
 
   export interface Settings {


### PR DESCRIPTION
My current build environment is fairly strict with typings and gives the following error:

```
> tsc --noEmit

node_modules/gelf-pro/typings/index.d.ts:28:19 - error TS7010: 'send', which lacks return-type annotation, implicitly has an 'any' return type.

28   export function send(message: Message, callback: MessageCallback);
                     ~~~~

node_modules/gelf-pro/typings/index.d.ts:29:19 - error TS7010: 'message', which lacks return-type annotation, implicitly has an 'any' return type.

29   export function message(message: Message, lvl: number, extra?: MessageExtra, callback?: MessageCallback);
                     ~~~~~~~

node_modules/gelf-pro/typings/index.d.ts:35:5 - error TS7010: 'send', which lacks return-type annotation, implicitly has an 'any' return type.

35     send(message: Message, callback: MessageCallback);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/gelf-pro/typings/index.d.ts:36:5 - error TS7010: 'message', which lacks return-type annotation, implicitly has an 'any' return type.

36     message(message: Message, lvl: number, extra: any, callback: MessageCallback);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/gelf-pro/typings/index.d.ts:41:5 - error TS7010: 'send', which lacks return-type annotation, implicitly has an 'any' return type.

41     send(message: Message, callback: MessageCallback);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 5 errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! executor@1.0.0 build: `tsc --noEmit`
npm ERR! Exit status 1
```

This PR fixes the issues by adding explicit return value types to all of the functions.