### PR TITLE
Adds the correct Typescript typings for function returns and optional params

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,7 @@ declare module 'gelf-pro' {
   export type MessageExtra = object | Error;
   export type MessageCallback = (error?: Error, packetLength?: number) => void;
 
-  export function setConfig(opts: Partial<Settings>): void;
+  export function setConfig(opts: Partial<Settings>): Logger;
 
   export function getAdapter(): Adapter;
 
@@ -41,7 +41,7 @@ declare module 'gelf-pro' {
 
     send(message: Message, callback: MessageCallback): void;
 
-    message(message: Message, lvl: number, extra: any, callback: MessageCallback): void;
+    message(message: Message, lvl: number, extra?: any, callback?: MessageCallback): void;
   }
 
   export interface Adapter {


### PR DESCRIPTION
In Typescript, I should be able to do the following:

```
import * as log from 'gelf-pro';

const ERROR_LEVEL: number = 3;
// Set config returns the gelf logger
const gelfLogger: Logger = log.setConfig({
    adapterName: 'tcp'
});
// Extras and the callback are both optional based on the code
gelfLogger.message('Hello World!', ERROR_LEVEL); 
```
However, you'll get a typescript error stating that type void is not assignable to type Logger.

This PR updates the typings to make this work correctly.